### PR TITLE
update: add section descriptions and update university issuer example

### DIFF
--- a/credential-trust-establishment/spec.md
+++ b/credential-trust-establishment/spec.md
@@ -4,7 +4,7 @@ Credential Trust Establishment
 **Specification Status:** Strawman
 
 **Latest Draft:**
-  [identity.foundation/crendtial-trust-establishment](https://identity.foundation/trust-establishment)
+[identity.foundation/credential-trust-establishment](identity.foundation/credential-trust-establishment)
 
 Editors:
 ~ [Mike Ebert](https://www.linkedin.com/in/michaelebert/)
@@ -18,118 +18,257 @@ Participate:
 ------------------------------------
 
 ## Introduction
-
-Once trust lists are established, it is natural to extend trust establishment by defining roles and linking them to credentials for situations where
+Once you can create a trust list using Trust Establishment, it is useful to extend Trust Establishment by defining roles and linking them to credentials for situations where:
 1. Enumerating every trusted ecosystem participant in a governance file is not practical (or, in some cases, not possible).
-2. It may be desirable to verify a participant's trusted status via both the trust list entry AND a credential.
+2. It may be desirable to verify a participant's trusted status via a trust list entry AND/OR a credential.
 
-Some of the most important roles are those tied to the issuing of credentials, so it is also necessary to tie roles to credential schemas.
+Some of the most important roles are those tied to the issuing or verifying of credentials, so it is also necessary to tie roles to credential schemas.
 
 Collecting all of this information in one place for ecosystem participants to access is powerful and convenient. A governance file is one relatively simple method for delivering trust establishment information.
 
-Below are three examples of governance files which include sections for trust lists, schemas, roles, and general meta data.
+The following sections cover what is required to enable Credential Trust Establishment:
+- Schemas
+- Roles
+- Linking Participants to Roles
+- Governance File Metadata
 
-## University Diploma Example
-The granting and recognition of university diplomas involve a large number of organizations at various tiers.
+## Schemas
+It is very useful to provide a list of schemas which are used in an ecosystem. This list can be quite simple, basically listing schema IDs and a human-friendly name. Here is an example for a U.S.-based higher education ecosystem:
 
-Fundamentally, the U.S. Department of Education authorizes organizations to be accrediting bodies.
-These accrediting bodies review universities and their programs and state whether they are accredited or not.
-In turn, accredited universities grant diplomas to their students that are recognized by various companies, organizations, etc.
+```json
+...
+	"schemas": [
+		{
+			"id": "PdiVKGAjdiVKGAjLqtTroc:2:Accrediting_Body:1.0",
+			"name": "Accrediting Body",
+		},
+		{
+			"id": "BXtzYPyPdiVKGAjLqtPexs:2:University_Degree_Issuer:1.0",
+			"name": "University Degree Issuer",
+		},
+		{
+			"id": "QHqtjywxfZ3yYsFrRHFLQm:2:Bachelors_Degree:1.0",
+			"name": "Bachelors Degree",
+		},
+		{
+			"id": "JAjLqtPexs3yYsFrRHFLQm:2:Student_ID:1.0",
+			"name": "Student ID",
+		}
+	],
+...
+```
 
-This governance file includes schemas for accrediting organization, university, and diploma credentials. The role required to issue these credentials is included
-in the schema metadata.
+## Roles
+Roles are important in an ecosystem because they explain what the trusted ecosystem participants are trusted FOR.
 
-A sample participant of each type is included in the "participants" section.
+Roles are named using a string that is easily usable in programming code and, where necessary or useful, linked to a credential with a "granted_by" statement.
 
-The governance below includes roles for the U.S. Department of Education, the accrediting bodies, and universities.
-The U.S. Department of Education is granted the role of "accrediting_authorizer" directly in the governance file in the "participants" section.
-Accrediting organizations can be granted the role of "university_accreditor" in the file or via the credential indicated by schema ID in the roles section.
-Universities can also be granted the role of "university_diploma_issuer" in the file or via the credential indiciated by schema ID in the roles section.
-Finally, universities issue university diplomas to students (holders).
+Some actions that can be performed by a role make sense to include with the role, such as "issue" and "verify." These "verbs" are linked to particular schemas.
+
+In the future, it will make sense to create separate actions and workflows that describe what can be done in an ecosystem and link them to roles outside of the role declaration.
+
+```json
+...
+	"roles": {
+		"accrediting_authorizer": {
+			"issue": [
+				"PdiVKGAjdiVKGAjLqtTroc:2:Accrediting_Body:1.0"
+			]
+		},
+		"university_accreditor": {
+			"issue": [
+				"BXtzYPyPdiVKGAjLqtPexs:2:University_Degree_Issuer:1.0"
+			],
+			"granted_by": "PdiVKGAjdiVKGAjLqtTroc:2:Accrediting_Body:1.0"
+		},
+		"verify_student_id": {
+			"verify": [
+				"JAjLqtPexs3yYsFrRHFLQm:2:Student_ID:1.0"
+			],
+			"granted_by": "BXtzYPyPdiVKGAjLqtPexs:2:University_Degree_Issuer:1.0"
+		},
+		"issue_bachelors_degree": {
+			"issue": [
+				"Lor8tASDc74EA268Jvc8J2:2:Bachelors_Degree:1.0"
+			],
+			"granted_by": "BXtzYPyPdiVKGAjLqtPexs:2:University_Degree_Issuer:1.0"
+		},
+	}
+...
+```
+
+## Linking Participants to Roles
+Once schemas are listed and roles are described, they need to be linked to the trusted participants. This is done by adding a new section to the Trust Establishment section of the document.
+```json
+...
+			"https://example.com/roles.schema.json": {
+				"did:example:usdepartmentofeducation": {
+					"roles": [
+						"accrediting_authorizer"
+					]
+				},
+				"did:example:nwccu": {
+					"roles": [
+						"university_accreditor"
+					]
+				},
+				"did:example:brighamyounguniversity": {
+					"roles": [
+						"verify_student_id"
+						"issue_bachelors_degree",
+					]
+				}
+			}
+...
+```
+
+## Governance File Metadata
+As with Trust Establishment, it makes sense to add some meta data to the governance file to assist those who are using the file.
+
+The full University Diploma example used in this document is included as the first sample listed in the Appendix.
 
 ```json
 {
 	"@context": [
 		"https://github.com/hyperledger/aries-rfcs/blob/main/concepts/0430-machine-readable-governance-frameworks/context.jsonld"
 	],
-	"name": "University Diploma Governance",
+	"id": "c64846d1-cf60-4ac5-835e-cbd25569f2fa",
+	"name": "University Degree Governance",
 	"version": "1.0",
-	"format": "1.1",
-	"id": "<uuid>",
-	"description": "This document describes the governance and issuance of university diplomas in a machine readable way.",
-	"last_updated": "2022-10-09",
+	"format": "1.0",
+	"description": "This document describes the governance for issuing accredited university degrees in a machine readable way",
+	"last_updated": "2022-04-20T04:20:00Z",
+	"author": "did:example:usdepartmentofeducation",
 	"docs_uri": "https://url-for-docs...",
+	"ttl": 86400,
+...
+```
+
+## Appendix
+Below are three examples of governance files which include sections for schemas, trust establishment lists, roles, and governance file meta data.
+
+### University Diploma Example
+The granting and recognition of university diplomas involve a large number of organizations at various tiers.
+
+Fundamentally, the U.S. Department of Education authorizes organizations to be accrediting bodies.
+These accrediting bodies review universities and their programs and state whether they are accredited or not.
+In turn, accredited universities grant diplomas to their students that are recognized by various companies, organizations, etc.
+
+This governance file includes schemas for accrediting organization, university, and diploma credentials. The role required to issue these credentials is included in the schema metadata.
+
+A sample participant of each type is included in the "participants" section.
+
+The governance below includes roles for the U.S. Department of Education, the accrediting bodies, and universities.
+The U.S. Department of Education is granted the role of "accrediting_authorizer" directly in the governance file in the "participants" section.
+Accrediting organizations can be granted the role of "university_accreditor" in the file or via the credential indicated by schema ID in the roles section.
+Universities can also be granted the role of "verify_student_id" and "issue_bachelors_degree" in the file or via the credential indicated by schema ID in the roles section.
+Finally, universities verify student IDs and issue degrees (such as a bachelors degree) to students (holders).
+
+```json
+{
+	"@context": [
+		"https://github.com/hyperledger/aries-rfcs/blob/main/concepts/0430-machine-readable-governance-frameworks/context.jsonld"
+	],
+	"id": "c64846d1-cf60-4ac5-835e-cbd25569f2fa",
+	"name": "University Degree Governance",
+	"version": "1.0",
+	"format": "1.0",
+	"description": "This document describes the governance for issuing accredited university degrees in a machine readable way",
+	"last_updated": "2022-04-20T04:20:00Z",
+	"author": "did:example:usdepartmentofeducation",
+	"docs_uri": "https://url-for-docs...",
+	"ttl": 86400,
 	"schemas": [
 		{
-			"id": "RuuJwd3JMffNwZ43DcJKN1:2:University_Accreditation_Issuer:1.0",
-			"name": "University Accreditation Issuer",
-			"issuer_roles": ["accrediting_authorizer"]
+			"id": "PdiVKGAjdiVKGAjLqtTroc:2:Accrediting_Body:1.0",
+			"name": "Accrediting Body",
 		},
 		{
-			"id": "RuuJwd3JMffNwZ43DcJKN1:2:University_Diploma_Issuer:1.2",
-			"name": "University Diploma Issuer",
-			"issuer_roles": ["university_accreditor"]
+			"id": "BXtzYPyPdiVKGAjLqtPexs:2:University_Degree_Issuer:1.0",
+			"name": "University Degree Issuer",
 		},
 		{
-			"id": "4CLG5pU5v294VdkMWxSByu:2:Bachelors_of_Science:1.5",
-			"name": "Bachelors_of_Science",
-			"issuer_roles": ["university_diploma_issuer"],
+			"id": "QHqtjywxfZ3yYsFrRHFLQm:2:Bachelors_Degree:1.0",
+			"name": "Bachelors Degree",
+		},
+		{
+			"id": "JAjLqtPexs3yYsFrRHFLQm:2:Student_ID:1.0",
+			"name": "Student ID",
 		}
 	],
 	"participants": {
-		"id": "32f54163-7166-48f1-93d8-ff217bdb0653",
+		"id": "1e762324-6a45-4f6a-b124-ecb21190fe09",
 		"author": "did:example:usdepartmentofeducation",
-		"created": "2020-01-01T19:23:24Z",
+		"created": "2022-04-20T04:20:00Z",
 		"version": 2,
-		"topic": "uri:to-multi-topic-schema",
 		"entries": {
-			"did:example:usdepartmentofeducation": {
-				"uri:to-role_schema": {
-					"roles": ["accrediting_authorizer"],
-				},
-				"uri:to-describe_schema": {
+			"https://example.com/description.schema.json": {
+				"did:example:usdepartmentofeducation": {
 					"name": "U.S. Department of Education",
 					"website": "https://www.ed.gov/accreditation",
 					"email": "accreditation@www.ed.gov"
-				}
-			},
-			"did:example:nwccu": {
-				"uri:to-role_schema": {
-					"roles": ["university_accreditor"],
 				},
-				"uri:to-describe_schema": {
+				"did:example:nwccu": {
 					"name": "Northwest Commission on Colleges and Universities",
 					"website": "http://www.nwccu.org/",
 					"email": "accrediting@nwccu.org"
-				}
-			},
-			"did:example:brighamyounguniversity": {
-				"uri:to-role_schema": {
-					"roles": ["university_diploma_issuer"]
 				},
-				"uri:to-describe_schema": {
+				"did:example:brighamyounguniversity": {
 					"name": "Brigham Young University",
 					"website": "https://www.byu.edu/",
 					"email": "graduation@byu.edu"
+				}
+			},
+			"https://example.com/roles.schema.json": {
+				"did:example:usdepartmentofeducation": {
+					"roles": [
+						"accrediting_authorizer"
+					]
+				},
+				"did:example:nwccu": {
+					"roles": [
+						"university_accreditor"
+					]
+				},
+				"did:example:brighamyounguniversity": {
+					"roles": [
+						"verify_student_id"
+						"issue_bachelors_degree",
+					]
 				}
 			}
 		}
 	},
 	"roles": {
-		"accrediting_authorizer": {},
+		"accrediting_authorizer": {
+			"issue": [
+				"PdiVKGAjdiVKGAjLqtTroc:2:Accrediting_Body:1.0"
+			]
+		},
 		"university_accreditor": {
-			"credentials": ["RuuJwd3JMffNwZ43DcJKN1:2:University_Accreditation_Issuer:1.4"]
+			"issue": [
+				"BXtzYPyPdiVKGAjLqtPexs:2:University_Degree_Issuer:1.0"
+			],
+			"granted_by": "PdiVKGAjdiVKGAjLqtTroc:2:Accrediting_Body:1.0"
 		},
-		"university_diploma_issuer": {
-			"credentials": ["RuuJwd3JMffNwZ43DcJKN1:2:University_Diploma_Issuer:1.4"]
+		"verify_student_id": {
+			"verify": [
+				"JAjLqtPexs3yYsFrRHFLQm:2:Student_ID:1.0"
+			],
+			"granted_by": "BXtzYPyPdiVKGAjLqtPexs:2:University_Degree_Issuer:1.0"
 		},
-		"holder": {}
+		"issue_bachelors_degree": {
+			"issue": [
+				"Lor8tASDc74EA268Jvc8J2:2:Bachelors_Degree:1.0"
+			],
+			"granted_by": "BXtzYPyPdiVKGAjLqtPexs:2:University_Degree_Issuer:1.0"
+		},
 	}
 }
 ```
 
 
-## DIF Membership Example
+### DIF Membership Example
 The DIF regulates which organizations and individuals can be members and participate in DIF activities. Their governance is relatively
 simple but could unlock a lot of powerful interactions via named and/or credentialed participants.
 
@@ -209,7 +348,7 @@ The governance file lists three roles: one for the DIF itself, one for organizat
 }
 ```
 
-## Aries Email Ecosystem Example
+### Aries Email Ecosystem Example
 The Aries community shares code, demos, and examples to promote interoperability and community education.
 The Aries community could create a simple demo that shows how agents, credential issuance and verification, and basic governance work in a simple
 email-based ecosystem.

--- a/credential-trust-establishment/spec.md
+++ b/credential-trust-establishment/spec.md
@@ -22,7 +22,7 @@ Once you can create a trust list using Trust Establishment, it is useful to exte
 1. Enumerating every trusted ecosystem participant in a governance file is not practical (or, in some cases, not possible).
 2. It may be desirable to verify a participant's trusted status via a trust list entry AND/OR a credential.
 
-Some of the most important roles are those tied to the issuing or verifying of credentials, so it is also necessary to tie roles to credential schemas.
+Some of the most important roles are those tied to the issuing and/or verifying of credentials, so it is also necessary to tie roles to credential schemas.
 
 Collecting all of this information in one place for ecosystem participants to access is powerful and convenient. A governance file is one relatively simple method for delivering trust establishment information.
 

--- a/credential-trust-establishment/spec.md
+++ b/credential-trust-establishment/spec.md
@@ -18,7 +18,7 @@ Participate:
 ------------------------------------
 
 ## Introduction
-Once you can create a trust list using Trust Establishment, it is useful to extend Trust Establishment by defining roles and linking them to credentials for situations where:
+Once you can create a trust list using [Trust Establishment](https://identity.foundation/trust-establishment/) , it is useful to extend Trust Establishment by defining roles and linking them to credentials for situations where:
 1. Enumerating every trusted ecosystem participant in a governance file is not practical (or, in some cases, not possible).
 2. It may be desirable to verify a participant's trusted status via a trust list entry AND/OR a credential.
 

--- a/specs.json
+++ b/specs.json
@@ -4,8 +4,8 @@
       "title": "Credential Trust Establishment",
       "spec_directory": "./credential-trust-establishment",
       "output_path": "./build",
-      "logo": "logo.svg",
-      "logo_link": "https://github.com/decentralized-identity/spec-up",
+      "logo": "https://rawcdn.githack.com/decentralized-identity/decentralized-identity.github.io/a3ca39717e440302d1fd99a796e7f00e1c42eb2d/images/logo-flat.svg",
+      "logo_link": "https://identity.foundation/",
       "source": {
         "host": "github",
         "account": "decentralized-identity",


### PR DESCRIPTION
Here is an update to utilize the Trust Establishment version 1 format for Credential Trust Establishment.

I also added some explanations of each section of the governance file.

To Do:
Update the DIF and Aries Email Ecosystem examples